### PR TITLE
Change json to jsonb type

### DIFF
--- a/src/adapters/postgresql-adapter.ts
+++ b/src/adapters/postgresql-adapter.ts
@@ -31,7 +31,7 @@ export class PostgreSQLAdapter implements IDatabaseAdapter {
 			await sql`CREATE SCHEMA IF NOT EXISTS obsidian`;
 			await sql`CREATE TABLE IF NOT EXISTS obsidian.file (
 					path text PRIMARY KEY,
-					dataview_data json
+					dataview_data jsonb
 			);`;
 			console.log("Created initial schema");
 		} finally {


### PR DESCRIPTION
Thanks for the great plugin!
It seems to me that it doesn't make sense to use JSON type to store metainformation data.  JSONB essentially has only one disadvantage over JSON, which is write speed. But with as much data as in Obsidian storage it shouldn't make any difference. But the speed and capabilities of the binary format is significantly better.
You can read some details for example [here](https://www.educba.com/postgresql-json-vs-jsonnb/).

For users who already have databases created, you can probably add a line to the migrate function. But here I'm not sure, because this ALTER will be done for each insertion into the database

```sql
ALTER TABLE obsidian.file ALTER COLUMN dataview_data TYPE JSONB;
```
